### PR TITLE
Uses URL location from react-router

### DIFF
--- a/imports/components/fileList.js
+++ b/imports/components/fileList.js
@@ -64,6 +64,7 @@ class FileList extends Component {
     } if (!this.state.passwordEntered) {
       return (
         <div>
+          <h1>{this.props.url}</h1>
           <Password
             handlePassword={this.handlePassword}
             addErrorTimer={addErrorTimer}
@@ -79,14 +80,13 @@ class FileList extends Component {
   }
 }
 
-// subscriptions(redux and meteor)
-
-const fileListWithTracker = withTracker(() => {
-  const urlParam = window.location.pathname.slice(1);
+const fileListWithTracker = withTracker((location) => {
+  const urlParam = location.location.pathname.slice(1);
   const fileSub = Meteor.subscribe('files', urlParam);
   return {
     loading: fileSub.ready(),
     files: MongoFiles.find({}).fetch(),
+    url: urlParam,
   };
 })(FileList);
 


### PR DESCRIPTION
# Uses URL location from `react-router`
This is so we can display the location URL to the user on each FileList page as the main title when styling comes into play.
Fixes #37 
## Functionality Description
* Utilizes React-Router's `location` object to retrieve the current url, instead of the `window` object.
* Passes the `url` prop to `FileList`
## Package Changes
None.
## Tests Added
None.