### PR TITLE
Limit file types

### DIFF
--- a/client/stylesheets/file-list.css
+++ b/client/stylesheets/file-list.css
@@ -1,3 +1,6 @@
+.file-list-container {
+}
+
 .file-list-container h1 {
   font-family: 'FiraCode', sans-serif;
 }
@@ -8,6 +11,17 @@
   color: var(--instruction-text-primary);
   border: 3px solid var(--border-primary);
   background-color: var(--instruction-background);
+}
+
+.file-list-loading {
+  text-align: center;
+}
+
+.file-list-loading .loading {
+  border: 3px solid var(--title-primary);
+  background: linear-gradient(to bottom, var(--file-background-primary) 50%, var(--file-background-secondary));
+  padding: 12px 12px 4px 12px;
+  display: inline-block;
 }
 
 .file-list-grid {

--- a/client/stylesheets/files.css
+++ b/client/stylesheets/files.css
@@ -11,16 +11,40 @@
   grid-template-rows: auto;
   grid-template-columns: auto minmax(225px, auto);
   grid-template-areas:
-    "file comments-container";
+    "file-container comments-container";
   align-items: center;
+}
+
+.file-container {
+  grid-area: file-container;
+  place-self: center;
+  display: grid;
+  grid: auto 40px / auto;
+  grid-template-areas:
+    "file"
+    "download";
 }
 
 .file {
   grid-area: file;
-  place-self: center;
   min-width: 250px;
   max-width: 100%;
   height: auto;
+}
+
+.download {
+  grid-area: download;
+  text-align: center;
+  place-self: center;
+}
+
+.download .button {
+  box-sizing: border-box;
+  font-size: .8rem;
+  padding: 9px;
+  text-decoration: none;
+  border: 2px solid var(--button-border);
+
 }
 
 .comments-container {

--- a/client/stylesheets/home.css
+++ b/client/stylesheets/home.css
@@ -41,10 +41,39 @@
   padding: 12px 12px 4px 12px;
 }
 
-#files {
+.file-select-container {
   grid-area: files;
+  display: flex;
+  border: none;
+  margin: 0 50px;
+  padding: 10px;
+  height: 60px;
+  width: auto;
+  border-radius: 0;
+  background-color: var(--input-background);
+  color: var(--instruction-text-primary);
+  border: 3px solid var(--button-border);
+}
+
+.upload-instructions {
+  font-size: .9rem;
+  align-self: center;
+}
+
+.upload-instructions li:last-child {
+  margin-top: 15px;
+}
+
+.asterisk {
+  color: var(--error-border);
+}
+
+#files {
   font-size: 1.25rem;
   cursor: pointer;
+  border: none;
+  height: 60px;
+  flex-grow: 2;
 }
 
 #passEncrypt {
@@ -52,8 +81,7 @@
   font-size: 1.5rem;
 }
 
-#passEncrypt,
-#files {
+#passEncrypt {
   border: none;
   margin: 0 50px;
   padding: 10px;

--- a/client/stylesheets/home.css
+++ b/client/stylesheets/home.css
@@ -22,11 +22,23 @@
 .home .upload-grid {
   display: grid;
   grid-row-gap: 35px;
-  grid-template-rows: auto auto;
+  grid-template-rows: auto auto auto;
   grid-template-columns: 50% 50%;
   grid-template-areas:
     "files password"
-    "upload upload";
+    "upload upload"
+    "loading loading";
+}
+
+.upload-loading {
+  grid-area: loading;
+  place-self: center;
+}
+
+.upload-loading .loading {
+  border: 3px solid var(--title-primary);
+  background: linear-gradient(to bottom, var(--file-background-primary) 50%, var(--file-background-secondary));
+  padding: 12px 12px 4px 12px;
 }
 
 #files {

--- a/imports/components/commentForm.js
+++ b/imports/components/commentForm.js
@@ -17,8 +17,8 @@ export default class CommentForm extends Component {
   render() {
     return (
       <form className="comment-form" onSubmit={this.handleFormSubmit}>
-        <input id="comment-name" type="text" placeholder="Name (optional)" onChange={(evt) => { this.setState({ author: evt.target.value }); }} />
-        <textarea id="comment-text" placeholder="Comment..." onChange={(evt) => { this.setState({ comment: evt.target.value }); }} />
+        <input id="comment-name" type="text" placeholder="Name" onChange={(evt) => { this.setState({ author: evt.target.value }); }} />
+        <textarea id="comment-text" placeholder="Comment" onChange={(evt) => { this.setState({ comment: evt.target.value }); }} />
         <button id="comment-submit" className="button" type="submit">Submit</button>
       </form>
     );

--- a/imports/components/download.js
+++ b/imports/components/download.js
@@ -1,28 +1,24 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import extractMIMEType from '../helpers/extractMIMEType.js';
 import { generateURL } from '../helpers/fileUtilities.js';
 
 export default class Download extends Component {
-
   state = {
     fileName: generateURL(),
   };
 
   createDownloadLink = () => {
     const result = extractMIMEType(this.props.base64);
-    const fileName = this.state.fileName + '.' + result;
+    const fileName = `${this.state.fileName}.${result}`;
 
-    return(
-      <a href={this.props.blob} download={fileName}>Download</a>
+    return (
+      <div className="download">
+        <a className="button" href={this.props.blob} download={fileName}>Download file</a>
+      </div>
     );
-
   }
 
   render() {
-    return (
-      <div>
-        {this.createDownloadLink()}
-      </div>
-    );
+    return this.createDownloadLink();
   }
 }

--- a/imports/components/error.js
+++ b/imports/components/error.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
 
 export default function Error(props) {

--- a/imports/components/file.js
+++ b/imports/components/file.js
@@ -75,7 +75,7 @@ class File extends Component {
   renderFile = () => {
     if (this.state.decrypted) {
       return (
-        <div>
+        <div className="file-container">
           <img className="file" src={this.state.blobURL} alt={this.state.fileData.fileName} />
           <Download blob={this.state.blobURL} base64={this.state.fileData} />
         </div>

--- a/imports/components/fileLimitInstructions.js
+++ b/imports/components/fileLimitInstructions.js
@@ -1,0 +1,11 @@
+/* eslint-disable react/jsx-one-expression-per-line */
+import React from 'react';
+
+export default function FileLimitInstructions() {
+  return (
+    <ul className="upload-instructions">
+      <li><span className="asterisk">*</span> Image files only</li>
+      <li><span className="asterisk">*</span> File size limit of 5MB</li>
+    </ul>
+  );
+}

--- a/imports/components/fileList.js
+++ b/imports/components/fileList.js
@@ -65,7 +65,9 @@ class FileList extends Component {
   render() {
     if (!this.props.loading) {
       return (
-        <Loading message="Loading files..." />
+        <div className="file-list-loading">
+          <Loading message="Downloading files..." />
+        </div>
       );
     } if (!this.state.passwordEntered) {
       return (

--- a/imports/components/passwordDecrypt.js
+++ b/imports/components/passwordDecrypt.js
@@ -23,9 +23,6 @@ export default class Password extends Component {
     if (pass.length === 0) {
       result.passwordValid = false;
       result.message = 'Password cannot be blank.';
-    } else if (pass.length <= 5) {
-      result.passwordValid = false;
-      result.message = 'Password needs to be longer than 5 characters.';
     }
     return result;
   }

--- a/imports/components/upload.js
+++ b/imports/components/upload.js
@@ -13,6 +13,7 @@ import {
 import addErrorTimer from '../helpers/addErrorTimer.js';
 import Password from './passwordEncrypt.js';
 import Loading from './loading.js';
+import FileLimitInstructions from './fileLimitInstructions.js';
 
 class Upload extends Component {
   constructor (props) {
@@ -87,13 +88,13 @@ class Upload extends Component {
       const invalidSize = self.fileSizeInvalid(file.size);
       let errorMessage = '';
       if (invalidType && invalidSize) {
-        errorMessage = `The file ${file.name} is not an accepted file type and is larger than 5MB.`;
+        errorMessage = `${file.name} is an invalid file type of ${file.type} and is larger than 5 MB.`;
         addErrorTimer(errorMessage);
       } else if (invalidType) {
-        errorMessage = `The file ${file.name} is not an accepted file type.`;
+        errorMessage = `${file.name} has an invalid file type of ${file.type}.`;
         addErrorTimer(errorMessage);
       } else if (invalidSize) {
-        errorMessage = `The file ${file.name} is larger than 5MB.`;
+        errorMessage = `${file.name} is larger than 5MB.`;
         addErrorTimer(errorMessage);
       }
       return invalidType || invalidSize;
@@ -135,7 +136,10 @@ class Upload extends Component {
     if (this.state.uploaded) return <Redirect to={this.state.url} />;
     return (
       <form className="upload-grid" onSubmit={this.fileSubmitHandler}>
-        <input type="file" id="files" multiple />
+        <div className="file-select-container">
+          <input type="file" id="files" multiple />
+          <FileLimitInstructions />
+        </div>
         <Password
           handlePassword={this.handlePassword}
           addErrorTimer={addErrorTimer}

--- a/imports/components/upload.js
+++ b/imports/components/upload.js
@@ -76,6 +76,30 @@ class Upload extends Component {
     });
   }
 
+  fileTypeInvalid = fileType => !fileType.match(/image\/(gif|jpeg|jpg|png|bmp)/i)
+
+  fileSizeInvalid = fileSize => fileSize >= 5000000 // 5 MB
+
+  filesInvalid = (fileList) => {
+    const self = this;
+    return Array.from(fileList).some(function(file) {
+      const invalidType = self.fileTypeInvalid(file.type);
+      const invalidSize = self.fileSizeInvalid(file.size);
+      let errorMessage = '';
+      if (invalidType && invalidSize) {
+        errorMessage = `The file ${file.name} is not an accepted file type and is larger than 5MB.`;
+        addErrorTimer(errorMessage);
+      } else if (invalidType) {
+        errorMessage = `The file ${file.name} is not an accepted file type.`;
+        addErrorTimer(errorMessage);
+      } else if (invalidSize) {
+        errorMessage = `The file ${file.name} is larger than 5MB.`;
+        addErrorTimer(errorMessage);
+      }
+      return invalidType || invalidSize;
+    });
+  }
+
   fileSubmitHandler = (event) => {
     event.preventDefault();
     const fileList = document.querySelector('#files').files;
@@ -91,6 +115,8 @@ class Upload extends Component {
       this.promiseFileLoader(fileList);
     } else if (fileList.length < 1) {
       addErrorTimer('You must select a file.');
+    } else if (this.filesInvalid(fileList)) {
+      // If the files in the list are valid
     } else if (!this.state.passwordValidated) {
       addErrorTimer(this.state.passwordError);
     }

--- a/imports/components/upload.js
+++ b/imports/components/upload.js
@@ -115,7 +115,11 @@ class Upload extends Component {
           addErrorTimer={addErrorTimer}
         />
         <button type="submit" className="button" disabled={this.state.loading}>Upload</button>
-        {this.state.loading && <Loading message={this.state.statusMessage} />}
+        {this.state.loading && (
+        <div className="upload-loading">
+          <Loading message={this.state.statusMessage} />
+        </div>
+        )}
       </form>
     );
   }

--- a/imports/helpers/extractMIMEType.js
+++ b/imports/helpers/extractMIMEType.js
@@ -1,9 +1,8 @@
 export default function extractMIMEType(base64String) {
-
-  if(typeof base64String !== 'string'){
+  if (typeof base64String !== 'string') {
     return null;
   }
-  
+
   const mime = base64String.match(/data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*/);
   const split = mime[1].split('/');
   const fileType = split[1];

--- a/server/main.js
+++ b/server/main.js
@@ -31,7 +31,7 @@ Meteor.methods({
     check(id, String);
     check(comment, { author: String, comment: String });
     if (comment.author.length === 0 && comment.comment.length === 0) {
-      throw new Meteor.Error('Name and comment can\'t be blank.');
+      throw new Meteor.Error('Name and comment cannot be blank.');
     } else if (MongoComments.findOne({ _id: id }) === undefined) {
       try {
         MongoComments.insert({ _id: id, comments: [comment] });


### PR DESCRIPTION
# Limit file types
Fixes #36 
## Functionality Description
* Limits each file to 5MB or less
* Limits each file to allow only `png`, `gif`, `jpeg`, `jpg` and `bmp` image files
* Styles instructions on main page
* Errors displayed if either & both cases are present.
## Package Changes
None
## Tests Added
None