### PR TITLE
Fixes Download component error

### DIFF
--- a/imports/components/file.js
+++ b/imports/components/file.js
@@ -77,7 +77,9 @@ class File extends Component {
       return (
         <div className="file-container">
           <img className="file" src={this.state.blobURL} alt={this.state.fileData.fileName} />
-          <Download blob={this.state.blobURL} base64={this.state.fileData} />
+          {this.state.blobCreated && (
+            <Download blob={this.state.blobURL} base64={this.state.fileData} />
+          )}
         </div>
       );
     }


### PR DESCRIPTION
# Fixes Download Component erroring
Fixes #53 
## Functionality Description
Conditionally renders the Download component. When there isn't a correct password, the extractMIMEType.js file throws an exception when trying to `split()` on `null`.
## Package Changes
None
## Tests Added
None